### PR TITLE
Update to Nexus 2.11.2-06

### DIFF
--- a/.openshift/action_hooks/build
+++ b/.openshift/action_hooks/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export NEXUS_VERSION=2.11.1-01
+export NEXUS_VERSION=2.11.2-06
 
 export NEXUS_APP_DIR=nexus-${NEXUS_VERSION}
 export NEXUS_BUNDLE_FILE=nexus-${NEXUS_VERSION}-bundle.tar.gz
@@ -53,3 +53,16 @@ ln -s $OPENSHIFT_DIY_LOG_DIR logs
 
 echo "ensuring pseudo userhome exists"
 mkdir -p $OPENSHIFT_DATA_DIR/userhome
+
+echo "updating wrapper"
+rm ${OPENSHIFT_DATA_DIR}/$NEXUS_APP_DIR/bin/jsw/lib/libwrapper-*
+rm ${OPENSHIFT_DATA_DIR}/$NEXUS_APP_DIR/bin/jsw/lib/wrapper-*
+rm ${OPENSHIFT_DATA_DIR}/$NEXUS_APP_DIR/bin/jsw/linux-x86-64/wrapper
+curl -o ${OPENSHIFT_DATA_DIR}wrapper-delta-pack-3.5.9.tar.gz http://wrapper.tanukisoftware.com/download/3.5.9/wrapper-delta-pack-3.5.9.tar.gz
+tar -zxvf ${OPENSHIFT_DATA_DIR}wrapper-delta-pack-3.5.9.tar.gz -C ${OPENSHIFT_DATA_DIR}
+rm ${OPENSHIFT_DATA_DIR}wrapper-delta-pack-3.5.9.tar.gz
+cp ${OPENSHIFT_DATA_DIR}wrapper-delta-pack-3.5.9/lib/wrapper.jar ${OPENSHIFT_DATA_DIR}/$NEXUS_APP_DIR/bin/jsw/lib/wrapper-3.2.3.jar
+cp ${OPENSHIFT_DATA_DIR}wrapper-delta-pack-3.5.9/bin/wrapper-linux-x86-64 ${OPENSHIFT_DATA_DIR}/$NEXUS_APP_DIR/bin/jsw/linux-x86-64/wrapper
+cp ${OPENSHIFT_DATA_DIR}wrapper-delta-pack-3.5.9/lib/libwrapper-linux-x86-64.so ${OPENSHIFT_DATA_DIR}/$NEXUS_APP_DIR/bin/jsw/lib/libwrapper.so
+
+echo "wrapper.backend.type=PIPE" >> ${OPENSHIFT_DATA_DIR}/$NEXUS_APP_DIR/bin/jsw/conf/wrapper.conf

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The problem with other Openshift Nexus projects boil down to three main problems
 
 [Sonatype Nexus](http://www.sonatype.org/nexus/) serves as a Maven repository.
 
-Current Deploy Version: ***2.11.1-01*** community edition
+Current Deploy Version: ***2.11.2-06*** community edition
 
 The deploy version can be changed by setting the version in the `.openshift/action_hooks/build` script.
 


### PR DESCRIPTION
Update to Nexus 2.11.2-06 and fix "unable to bind listener to any port in the range 32000-32999" issue updating wrapper to use "wrapper.backend.type=PIPE" config